### PR TITLE
Update CI dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
       - name: Cache Maven
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/deps.edn') }}
 
       - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.5.0
+        uses: turtlequeue/setup-babashka@v1.7.0
         with:
           babashka-version: 1.3.189
 


### PR DESCRIPTION
closes #3 

I used liquidz/antq to update CI dependency.

```
$ clojure -Sdeps '{:deps {org.slf4j/slf4j-simple {:mvn/version "RELEASE"} com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -M -m antq.core --upgrade --force
...

| :file                    | :name                      | :current | :latest |
|--------------------------|----------------------------|----------|---------|
| .github/workflows/ci.yml | actions/cache              | v2       | v4.3.0  |
|                          | actions/checkout           | v4       | v5      |
|                          | turtlequeue/setup-babashka | v1.5.0   | v1.7.0  |

Available changes:
- https://github.com/actions/cache/compare/v2...v4.3.0
- https://github.com/actions/checkout/blob/v5/CHANGELOG.md
- https://github.com/turtlequeue/setup-babashka/compare/v1.5.0...v1.7.0
```